### PR TITLE
Add '_check_validity'

### DIFF
--- a/pairing/pairing.py
+++ b/pairing/pairing.py
@@ -100,6 +100,25 @@ def _find_intersection(a, b):
     intersection = np.maximum(a, b)
     return intersection
 
+def _check_validity(c_I):
+    """
+    Check validity of indirect connectivity matrix
+
+    Parameters
+    ----------
+    c_I : np.ndarray
+    indirect connectivity matrix to test
+
+    Returns
+    -------
+    Boolean 'True' or 'False'
+    """
+
+    test_indirect = generate_indirect_connectivity(c_I)
+    if (test_indirect == c_I).all():
+        return True
+    else:
+        return False
 
 if __name__ == "__main__":
     # Do something if this file is invoked on its own

--- a/pairing/pairing.py
+++ b/pairing/pairing.py
@@ -115,10 +115,7 @@ def _check_validity(c_I):
     """
 
     test_indirect = generate_indirect_connectivity(c_I)
-    if (test_indirect == c_I).all():
-        return True
-    else:
-        return False
+    return (test_indirect == c_I).all()
 
 if __name__ == "__main__":
     # Do something if this file is invoked on its own

--- a/pairing/tests/test_pairing.py
+++ b/pairing/tests/test_pairing.py
@@ -10,7 +10,6 @@ import mdtraj as md
 from pairing.utils.io import get_fn
 import pairing
 
-
 def test_generate_direct_correlation():
     trj = md.load(get_fn('sevick1988.gro'))
 
@@ -41,3 +40,21 @@ def test_sevick1988():
                       [1, 1, 1, 0, 1]], dtype=np.int32)
 
     assert (c_I == pairing.generate_indirect_connectivity(c_D)).all()
+
+def test_check_validity_pass():
+    c_I = np.asarray([[1, 1, 1, 0, 1],
+                      [1, 1, 1, 0, 1],
+                      [1, 1, 1, 0, 1],
+                      [0, 0, 0, 1, 0],
+                      [1, 1, 1, 0, 1]], dtype=np.int32)
+
+    assert pairing.pairing._check_validity(c_I) == True
+
+def test_check_validity_fail():
+    c_intermediate = np.asarray([[1, 0, 0, 0, 1],
+                                 [0, 1, 1, 0, 0],
+                                 [1, 1, 1, 0, 1],
+                                 [0, 0, 0, 1, 0],
+                                 [1, 0, 1, 0, 1]], dtype=np.int32)
+
+    assert pairing.pairing._check_validity(c_intermediate) == False


### PR DESCRIPTION
Add a function that checks the validity of an indirect connectivity matrix.  This function does so by calling `generate_indirect_connectivity` on the input indirect matrix and compares the two.

TODO: Before merging, we need to consider how the `generate_indirect_connectivity` function needs to change to accommodate `_check_validity`.  `generate_indirect_connectivity` needs to be able to handle two cases:

- general case where the indirect matrix will be calculated until it equals the matrix calculated from `_check_validity`

- case specifically for `_check_validity` where the indirect matrix will only be calculated once