### PR TITLE
Add tests for 'generate_clusters' and 'analyze_clusters' functions

### DIFF
--- a/pairing/tests/test_pairing.py
+++ b/pairing/tests/test_pairing.py
@@ -46,7 +46,7 @@ def test_check_validity_pass():
     c_I = np.asarray([[1, 1, 1, 0, 1],
                       [1, 1, 1, 0, 1],
                       [1, 1, 1, 0, 1],
-                      [0, 0, 0, 1, 0], 
+                      [0, 0, 0, 1, 0],
                       [1, 1, 1, 0, 1]], dtype=np.int32)
 
     assert pairing.pairing._check_validity(c_I) == True

--- a/pairing/tests/test_pairing.py
+++ b/pairing/tests/test_pairing.py
@@ -46,7 +46,7 @@ def test_check_validity_pass():
     c_I = np.asarray([[1, 1, 1, 0, 1],
                       [1, 1, 1, 0, 1],
                       [1, 1, 1, 0, 1],
-                      [0, 0, 0, 1, 0],
+                      [0, 0, 0, 1, 0], 
                       [1, 1, 1, 0, 1]], dtype=np.int32)
 
     assert pairing.pairing._check_validity(c_I) == True
@@ -68,3 +68,24 @@ def test_40_atoms():
     indirect = pairing.generate_indirect_connectivity(direct)
 
     assert indirect.dtype == np.int32
+
+def test_indirect_matrix_reduction():
+    trj = md.load(get_fn('sevick1988.gro'))
+    direct = pairing.generate_direct_correlation(trj, cutoff=0.8)
+    indirect = pairing.generate_indirect_connectivity(direct)
+
+    c_R = np.asarray([[0, 1],
+                      [0, 1],
+                      [0, 1],
+                      [1, 0],
+                      [0, 1]])
+    
+    assert (c_R == pairing.generate_clusters(indirect)).all()
+
+def test_cluster_analysis():
+    trj = md.load(get_fn('sevick1988.gro'))
+    direct = pairing.generate_direct_correlation(trj, cutoff=0.8)
+    indirect = pairing.generate_indirect_connectivity(direct)
+    reduction = pairing.generate_clusters(indirect)
+
+    assert pairing.analyze_clusters(reduction) == (2.5, 1.5)


### PR DESCRIPTION
Two unit tests added to `test_pairing.py`.

1) `test_indirect_matrix_reduction` tests to to make sure `generate_clusters` correctly reduces the indirect correlation matrix.

1) `test_cluster_analysis` tests to make sure `analyze_clusters` returns the correct average and standard deviation of the system.