### PR TITLE
Bump CI to Python 3.6 and 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,17 +8,17 @@ matrix:
     # Extra includes for OSX since python language is not available by default on OSX
     - os: osx
       language: generic
-      env: PYTHON_VER=3.5
+      env: PYTHON_VER=3.6
     - os: osx
       language: generic
-      env: PYTHON_VER=3.6
+      env: PYTHON_VER=3.7
 
-    - os: linux
-      python: 3.5
-      env: PYTHON_VER=3.5
     - os: linux
       python: 3.6
       env: PYTHON_VER=3.6
+    - os: linux
+      python: 3.7
+      env: PYTHON_VER=3.7
 
 before_install:
     # Additional info about the build

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,13 +1,14 @@
 environment:
 
   matrix:
-    - PYTHON: "C:\\Miniconda35-x64"
-      PYTHON_VERSION: "3.5"
-      PYTHON_ARCH: "64"
-
-    - PYTHON: "C:\\Miniconda36-x64"
+    - PYTHON: "C:\\Miniconda3-x64"
+      CONDA_PY: "36"
+      ARCH: "64"
       PYTHON_VERSION: "3.6"
-      PYTHON_ARCH: "64"
+    - PYTHON: "C:\\Miniconda3-x64"
+      CONDA_PY: "37"
+      ARCH: "64"
+      PYTHON_VERSION: "3.7"
   
 
 install:


### PR DESCRIPTION
It's been a minute; out with the old (Python 3.5) and in with the fairly new (Python 3.7)